### PR TITLE
Refactor embedding code to provide a generic container

### DIFF
--- a/QuorumWebsite/SourceCode/Support/CodingOnline.quorum
+++ b/QuorumWebsite/SourceCode/Support/CodingOnline.quorum
@@ -8,7 +8,6 @@ use Libraries.Web.Page.PreformattedText
 use Libraries.Web.Page.Select
 use Libraries.Web.Page.Option
 use Libraries.Web.Page.UnorderedList
-use Libraries.Web.Page.Canvas
 use Libraries.Web.Page.CodeBlock
 use Libraries.Web.Page.Span
 use Libraries.Web.Page.Script
@@ -95,18 +94,17 @@ class CodingOnline is Division
 //        inputArea:AddAttribute("onkeydown",
 //            "keyboardInputShortcuts(event, '"+uniqueIdentifier + "IdeInput"+
 //            "', '"+uniqueIdentifier +"IdeOutput'" + 
-//            ", '"+uniqueIdentifier +"QuorumGraphicsCanvas')")
+//            ", '"+uniqueIdentifier +"QuorumUIContainer')")
 //        inputArea:AddAttribute("role", "textbox")              //aria attribute
 //        inputArea:AddAttribute("aria-multiline", "true")        //aria attribute
         //flexContainerInputOutput:Add(inputArea)
         flexContainerInputOutput:Add(AddCodeEditArea())
 
-        Canvas canvas
-        canvas:SetClassAttribute("ideVisualOutput")
-        canvas:SetIdentifier(uniqueIdentifier + "QuorumGraphicsCanvas")
-        canvas:AddAttribute("role", "application")
-        canvas:AddAttribute("tabindex", "0")
-        flexContainerInputOutput:Add(canvas)
+        Division uiContainer
+        uiContainer:SetClassAttribute("ideVisualOutput")
+        uiContainer:SetIdentifier(uniqueIdentifier + "QuorumUIContainer")
+        uiContainer:AddAttribute("style", "position: relative;")
+        flexContainerInputOutput:Add(uiContainer)
 
         codingSection:Add(flexContainerInputOutput)
 //        Input ideName
@@ -125,7 +123,7 @@ class CodingOnline is Division
         buildButton:SetClassAttribute("FlexBuildButton")
         buildButton:SetOnClick("newRunCode('" + uniqueIdentifier + "IdeInput" 
             + "', '" + uniqueIdentifier + "IdeOutput" 
-            + "', '" + uniqueIdentifier + "QuorumGraphicsCanvas" + "', false)")
+            + "', '" + uniqueIdentifier + "QuorumUIContainer" + "', false)")
         buildButton:AddText("Build (CTRL+B)")
         flexContainerRunButtons:Add(buildButton)
 
@@ -135,7 +133,7 @@ class CodingOnline is Division
         runButton:SetClassAttribute("FlexBuildButton")
         runButton:SetOnClick("newRunCode('" + uniqueIdentifier + "IdeInput" 
             + "', '" + uniqueIdentifier + "IdeOutput" 
-            + "', '" + uniqueIdentifier + "QuorumGraphicsCanvas" + "', true)")
+            + "', '" + uniqueIdentifier + "QuorumUIContainer" + "', true)")
         runButton:AddText("Run (CTRL+R)")
         flexContainerRunButtons:Add(runButton)
 
@@ -229,7 +227,7 @@ class CodingOnline is Division
         inputArea:AddAttribute("onkeydown",
             "keyboardInputShortcuts(event, '"+uniqueIdentifier + "IdeInput"+
             "', '"+uniqueIdentifier +"IdeOutput'" + 
-            ", '"+uniqueIdentifier +"QuorumGraphicsCanvas')")
+            ", '"+uniqueIdentifier +"QuorumUIContainer')")
         inputArea:SetClassAttribute("ideEditing")
         inputArea:SetSpellcheck(false)
         inputArea:AddAttribute("oninput", "editAreaUpdate(this); editAreaSyncScroll(this);")

--- a/QuorumWebsite/html/embed/embed-quorum.js
+++ b/QuorumWebsite/html/embed/embed-quorum.js
@@ -1,6 +1,6 @@
 var currentIDEInput_$Global_ = '';
 var currentIDEOutput_$Global_ = 'DefaultQuorumEnvironmentIdeOutput';
-var currentIDECanvas_$Global_ = 'QuorumGraphicsCanvas';
+var currentUIContainer_$Global_ = 'QuorumUIContainer';
 var total_console_length239847239482734 = 0;
 setInterval(update_console, 500);
 
@@ -57,19 +57,19 @@ var Module = {
     }
  };
 
-var keyboardInputShortcuts = function(event, input, output, canvas) {
+var keyboardInputShortcuts = function(event, input, output, uiContainer) {
     var key = event.keyCode;
     var active = event.getModifierState("Control");
     //CTRL + R, run a program
     if(key === 82 && active) {
-        newRunCode(input, output, canvas, true);
+        newRunCode(input, output, uiContainer, true);
     } else if (key === 66 && active) {
-        newRunCode(input, output, canvas, false);
+        newRunCode(input, output, uiContainer, false);
     }
 };
 
 //IDE stop program button action
-var stopProgram = function(canvas) {
+var stopProgram = function(uiContainer) {
     //prevent errors if nothing has been built yet
     if (typeof Stop === "function") { 
         Stop();
@@ -120,7 +120,7 @@ var updateLineNumbers = function(element, numLines) {
 };
 
 //IDE submit button action
-var newRunCode = function (input, output, canvas, execute) {
+var newRunCode = function (input, output, uiContainer, execute) {
     var codeInput = document.getElementById(input).querySelector(".ideEditing").value;
     var outputRegion = document.getElementById(output);
     
@@ -128,7 +128,7 @@ var newRunCode = function (input, output, canvas, execute) {
     var ideName = input.replace("IdeInput","");
     currentIDEInput_$Global_ = input;
     currentIDEOutput_$Global_ = output;
-    currentIDECanvas_$Global_ = canvas;
+    currentUIContainer_$Global_ = uiContainer;
     var codeData = {code: codeInput, pageURL: pageURL, ideName:ideName};
 
     var xmlhttp = new XMLHttpRequest();
@@ -223,15 +223,15 @@ var GenerateQuorumEnvironment = function(name) {
                "<div class= \"flex-container\" >" +
                   "<div id= \""+name+"IdeInput\" tabindex= \"-1\" class= \"ideTextboxInput\" >" +
                      "<textarea tabindex= \"-1\" aria-hidden= \"true\" class= \"ideLineNumbers\" spellcheck= \"false\" readonly= \"readonly\" >1</textarea>" +
-                     "<textarea id= \""+name+"ideTextboxInput\" spellcheck= \"false\" name= \"code\" onscroll= \"editAreaSyncScroll(this);\" tabindex= \"0\" class= \"ideEditing\" onkeydown= \"keyboardInputShortcuts(event, '"+name+"IdeInput', '"+name+"IdeOutput', '"+name+"QuorumGraphicsCanvas')\" aria-multiline= \"true\" oninput= \"editAreaUpdate(this); editAreaSyncScroll(this);\" ></textarea>" +
+                     "<textarea id= \""+name+"ideTextboxInput\" spellcheck= \"false\" name= \"code\" onscroll= \"editAreaSyncScroll(this);\" tabindex= \"0\" class= \"ideEditing\" onkeydown= \"keyboardInputShortcuts(event, '"+name+"IdeInput', '"+name+"IdeOutput', '"+name+"QuorumUIContainer')\" aria-multiline= \"true\" oninput= \"editAreaUpdate(this); editAreaSyncScroll(this);\" ></textarea>" +
                      "<pre aria-hidden= \"true\" tabindex= \"-1\" class= \"syntaxHighlighting\" ><code tabindex= \"-1\" class= \"language-quorum highlighting-content\" ></code></pre>" +
                      "<script  type=\"text/javascript\">window.addEventListener('pageshow', () => {var element = document.getElementById('"+name+"IdeInput').querySelector('.ideEditing');editAreaUpdate(element)});</script>" +
                   "</div>" +
-                  "<canvas id= \""+name+"QuorumGraphicsCanvas\" tabindex= \"0\" class= \"ideVisualOutput\" role= \"application\" ></canvas>" +
+                  "<div id= \""+name+"QuorumUIContainer\" style=\"position: relative;\" class= \"ideVisualOutput\" ></div>" +
                "</div>" +
                "<div class= \"flex-container\" >" +
-                  "<button id= \""+name+"BuildButton\" class= \"FlexBuildButton\" onclick= \"newRunCode('"+name+"IdeInput', '"+name+"IdeOutput', '"+name+"QuorumGraphicsCanvas', false)\" type= \"button\" >Build (CTRL+B)</button>" +
-                  "<button id= \""+name+"RunButton\" class= \"FlexBuildButton\" onclick= \"newRunCode('"+name+"IdeInput', '"+name+"IdeOutput', '"+name+"QuorumGraphicsCanvas', true)\" type= \"button\" >Run (CTRL+R)</button>" +
+                  "<button id= \""+name+"BuildButton\" class= \"FlexBuildButton\" onclick= \"newRunCode('"+name+"IdeInput', '"+name+"IdeOutput', '"+name+"QuorumUIContainer', false)\" type= \"button\" >Build (CTRL+B)</button>" +
+                  "<button id= \""+name+"RunButton\" class= \"FlexBuildButton\" onclick= \"newRunCode('"+name+"IdeInput', '"+name+"IdeOutput', '"+name+"QuorumUIContainer', true)\" type= \"button\" >Run (CTRL+R)</button>" +
                   "<button id= \""+name+"StopButton\" class= \"FlexBuildButton\" onclick= \"stopProgram()\" type= \"button\" >Stop Program</button>" +
                "</div>" +
             "</section>" +

--- a/QuorumWebsite/html/embedded_ide.php
+++ b/QuorumWebsite/html/embedded_ide.php
@@ -35,7 +35,7 @@
                   <div class= "flex-container" >
                      <div id= "embeddedIdeInput" tabindex= "-1" class= "ideTextboxInput" >
                         <textarea tabindex= "-1" aria-hidden= "true" class= "ideLineNumbers" spellcheck= "false" readonly= "readonly" >1</textarea>
-                        <textarea id= "embeddedideTextboxInput" spellcheck= "false" name= "code" onscroll= "editAreaSyncScroll(this);" tabindex= "0" class= "ideEditing" onkeydown= "keyboardInputShortcuts(event, 'embeddedIdeInput', 'embeddedIdeOutput', 'embeddedQuorumGraphicsCanvas')" aria-multiline= "true" oninput= "editAreaUpdate(this); editAreaSyncScroll(this);" ><?php print $_GET['embedcode'] ?></textarea>
+                        <textarea id= "embeddedideTextboxInput" spellcheck= "false" name= "code" onscroll= "editAreaSyncScroll(this);" tabindex= "0" class= "ideEditing" onkeydown= "keyboardInputShortcuts(event, 'embeddedIdeInput', 'embeddedIdeOutput', 'embeddedQuorumUIContainer')" aria-multiline= "true" oninput= "editAreaUpdate(this); editAreaSyncScroll(this);" ><?php print $_GET['embedcode'] ?></textarea>
                         <pre aria-hidden= "true" tabindex= "-1" class= "syntaxHighlighting" ><code tabindex= "-1" class= "language-quorum highlighting-content" ></code></pre>
                         <script  type="text/javascript">window.addEventListener('pageshow', () => {
                            var element = document.getElementById('embeddedIdeInput').querySelector('.ideEditing');
@@ -43,12 +43,11 @@
                            });
                         </script>
                      </div>
-                     <canvas id= "embeddedQuorumGraphicsCanvas" tabindex= "0" class= "ideVisualOutput" role= "application" >
-                     </canvas>
+                     <div id= "embeddedQuorumUIContainer" style= "position: relative;" class= "ideVisualOutput" ></div>
                   </div>
                   <div class= "flex-container" >
-                     <button id= "embeddedBuildButton" class= "FlexBuildButton" onclick= "newRunCode('embeddedIdeInput', 'embeddedIdeOutput', 'embeddedQuorumGraphicsCanvas', false)" type= "button" >Build (CTRL+B)</button>
-                     <button id= "embeddedRunButton" class= "FlexBuildButton" onclick= "newRunCode('embeddedIdeInput', 'embeddedIdeOutput', 'embeddedQuorumGraphicsCanvas', true)" type= "button" >Run (CTRL+R)</button>
+                     <button id= "embeddedBuildButton" class= "FlexBuildButton" onclick= "newRunCode('embeddedIdeInput', 'embeddedIdeOutput', 'embeddedQuorumUIContainer', false)" type= "button" >Build (CTRL+B)</button>
+                     <button id= "embeddedRunButton" class= "FlexBuildButton" onclick= "newRunCode('embeddedIdeInput', 'embeddedIdeOutput', 'embeddedQuorumUIContainer', true)" type= "button" >Run (CTRL+R)</button>
                      <button id= "embeddedStopButton" class= "FlexBuildButton" onclick= "stopProgram()" type= "button" >Stop Program</button>
                   </div>
                </section>

--- a/QuorumWebsite/html/project.php
+++ b/QuorumWebsite/html/project.php
@@ -153,7 +153,7 @@
                   <div class= "flex-container" >
                      <div id= "writeCodeIdeInput" tabindex= "-1" class= "ideTextboxInput" >
                         <textarea tabindex= "-1" aria-hidden= "true" class= "ideLineNumbers" spellcheck= "false" readonly= "readonly" >1</textarea>
-                        <textarea id= "writeCodeideTextboxInput" spellcheck= "false" name= "code" onscroll= "editAreaSyncScroll(this);" tabindex= "0" class= "ideEditing" onkeydown= "keyboardInputShortcuts(event, 'writeCodeIdeInput', 'writeCodeIdeOutput', 'writeCodeQuorumGraphicsCanvas')" aria-multiline= "true" oninput= "editAreaUpdate(this); editAreaSyncScroll(this);" ><?php print $code; ?></textarea>
+                        <textarea id= "writeCodeideTextboxInput" spellcheck= "false" name= "code" onscroll= "editAreaSyncScroll(this);" tabindex= "0" class= "ideEditing" onkeydown= "keyboardInputShortcuts(event, 'writeCodeIdeInput', 'writeCodeIdeOutput', 'writeCodeQuorumUIContainer')" aria-multiline= "true" oninput= "editAreaUpdate(this); editAreaSyncScroll(this);" ><?php print $code; ?></textarea>
                         <pre aria-hidden= "true" tabindex= "-1" class= "syntaxHighlighting" ><code tabindex= "-1" class= "language-quorum highlighting-content" ></code></pre>
                         <script  type="text/javascript">window.addEventListener('pageshow', () => {
                            var element = document.getElementById('writeCodeIdeInput').querySelector('.ideEditing');
@@ -161,12 +161,11 @@
                            });
                         </script>
                      </div>
-                     <canvas id= "writeCodeQuorumGraphicsCanvas" tabindex= "0" class= "ideVisualOutput" role= "application" >
-                     </canvas>
+                     <div id= "writeCodeQuorumUIContainer" style= "position: relative;" class= "ideVisualOutput" ></div>
                   </div>
                   <div class= "flex-container" >
-                     <button id= "writeCodeBuildButton" class= "FlexBuildButton" onclick= "newRunCode('writeCodeIdeInput', 'writeCodeIdeOutput', 'writeCodeQuorumGraphicsCanvas', false)" type= "button" >Build (CTRL+B)</button>
-                     <button id= "writeCodeRunButton" class= "FlexBuildButton" onclick= "newRunCode('writeCodeIdeInput', 'writeCodeIdeOutput', 'writeCodeQuorumGraphicsCanvas', true)" type= "button" >Run (CTRL+R)</button>
+                     <button id= "writeCodeBuildButton" class= "FlexBuildButton" onclick= "newRunCode('writeCodeIdeInput', 'writeCodeIdeOutput', 'writeCodeQuorumUIContainer', false)" type= "button" >Build (CTRL+B)</button>
+                     <button id= "writeCodeRunButton" class= "FlexBuildButton" onclick= "newRunCode('writeCodeIdeInput', 'writeCodeIdeOutput', 'writeCodeQuorumUIContainer', true)" type= "button" >Run (CTRL+R)</button>
                      <button id= "writeCodeStopButton" class= "FlexBuildButton" onclick= "stopProgram()" type= "button" >Stop Program</button>
                   </div>
                </section>

--- a/QuorumWebsite/html/run.php
+++ b/QuorumWebsite/html/run.php
@@ -76,8 +76,7 @@
                     <h2 class= "ideSubHeading" >Console Output</h2>
                     <pre id= "IdeOutput" class= "allInOneIdeOutput" role= "region" aria-atomic= "true" aria-label= "output of Development Environment" aria-live= "assertive" aria-relevant="additions"></pre>
                     <h2 class= "ideSubHeading" >Visual Output</h2>
-                    <canvas tabindex= "0" id= "QuorumGraphicsCanvas" class= "ideCanvas" role="application"></canvas>
-                    <script  type="text/javascript">var canvas = document.getElementById("QuorumGraphicsCanvas"); canvas.width = 800; canvas.height = 600;</script>
+                    <div style= "position: relative; width: 800px; height: 600px;" id= "QuorumUIContainer" class= "ideCanvas"></div>
                 </div>
                 <h2>Tips for using the Run Page</h2>
                 <p>This page allows us to run programs written in the Quorum 

--- a/QuorumWebsite/html/script/script.js
+++ b/QuorumWebsite/html/script/script.js
@@ -1,6 +1,6 @@
 var currentIDEInput_$Global_ = '';
 var currentIDEOutput_$Global_ = 'frontPageIdeOutput';
-var currentIDECanvas_$Global_ = 'QuorumGraphicsCanvas';
+var currentUIContainer_$Global_ = 'QuorumUIContainer';
 var total_console_length239847239482734 = 0;
 setInterval(update_console, 500);
 
@@ -463,19 +463,19 @@ var buildCode = function (input, output) {
     });
 };
 
-var keyboardInputShortcuts = function(event, input, output, canvas) {
+var keyboardInputShortcuts = function(event, input, output, uiContainer) {
     var key = event.keyCode;
     var active = event.getModifierState("Control");
     //CTRL + R, run a program
     if(key === 82 && active) {
-        newRunCode(input, output, canvas, true);
+        newRunCode(input, output, uiContainer, true);
     } else if (key === 66 && active) {
-        newRunCode(input, output, canvas, false);
+        newRunCode(input, output, uiContainer, false);
     }
 };
 
 //IDE stop program button action
-var stopProgram = function(canvas) {
+var stopProgram = function(uiContainer) {
     //prevent errors if nothing has been built yet
     if (typeof Stop === "function") { 
         Stop();
@@ -526,7 +526,7 @@ var updateLineNumbers = function(element, numLines) {
 };
 
 //IDE submit button action
-var newRunCode = function (input, output, canvas, execute) {
+var newRunCode = function (input, output, uiContainer, execute) {
 	// Attempt to stop previously running programs on this page first.
 	stopProgram();
 	
@@ -537,7 +537,7 @@ var newRunCode = function (input, output, canvas, execute) {
     var ideName = input.replace("IdeInput","");
     currentIDEInput_$Global_ = input;
     currentIDEOutput_$Global_ = output;
-    currentIDECanvas_$Global_ = canvas;
+    currentUIContainer_$Global_ = uiContainer;
     var codeData = {code: codeInput, pageURL: pageURL, ideName:ideName};
     $.ajax({
         type: "POST",


### PR DESCRIPTION
When embedding Quorum in a web page, the embedding page now simply provides a generic `div` as a container, not the canvas itself. This corresponds to the changes in data11y-llc/quorum-language#2.